### PR TITLE
Update membership unread counts after a subscription (feed) is removed from a group

### DIFF
--- a/app/controllers/rss_together/groups/subscriptions_controller.rb
+++ b/app/controllers/rss_together/groups/subscriptions_controller.rb
@@ -10,7 +10,7 @@ module RssTogether
     end
 
     def destroy
-      @subscription.destroy!
+      RemoveSubscriptionJob.perform_later(@subscription)
       flash[:success] = "Unsubscribed from #{truncate(@subscription.feed.title, length: 80)}"
       redirect_to group_subscriptions_path(@group), status: :see_other
     end

--- a/app/controllers/rss_together/reader/marks_controller.rb
+++ b/app/controllers/rss_together/reader/marks_controller.rb
@@ -43,7 +43,7 @@ module RssTogether
         @marks = policy_scope(current_membership.marks)
         affected_item_ids = @marks.collect(&:item_id)
 
-        ActiveRecord::Base.transaction do
+        current_membership.with_lock do
           current_membership.marks.update_all(unread: false)
           current_membership.update!(unread_count: 0)
         end

--- a/app/jobs/rss_together/mark_subscription_items_as_unread_job.rb
+++ b/app/jobs/rss_together/mark_subscription_items_as_unread_job.rb
@@ -11,9 +11,7 @@ module RssTogether
       subscription.with_lock do
         if items_payload.present?
           subscription.group.memberships.each do |membership|
-            membership.lock!
             membership.marks.insert_all(items_payload)
-            membership.update!(unread_count: membership.marks.unread.count)
           end
         end
 

--- a/app/jobs/rss_together/mark_subscription_items_as_unread_job.rb
+++ b/app/jobs/rss_together/mark_subscription_items_as_unread_job.rb
@@ -11,6 +11,7 @@ module RssTogether
       subscription.with_lock do
         if items_payload.present?
           subscription.group.memberships.each do |membership|
+            membership.lock!
             membership.marks.insert_all(items_payload)
             membership.update!(unread_count: membership.marks.unread.count)
           end

--- a/app/jobs/rss_together/remove_subscription_job.rb
+++ b/app/jobs/rss_together/remove_subscription_job.rb
@@ -1,0 +1,20 @@
+module RssTogether
+  class RemoveSubscriptionJob < ApplicationJob
+    queue_as :default
+
+    def perform(subscription)
+      subscription.with_lock do
+        subscription.feed.items.each do |item|
+          item.marks.where(reader: subscription.group.memberships).destroy_all
+        end
+
+        subscription.destroy!
+
+        subscription.group.memberships.each do |membership|
+          membership.lock!
+          membership.update!(unread_count: membership.marks.unread.count)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/rss_together/groups/subscriptions_controller_spec.rb
+++ b/spec/controllers/rss_together/groups/subscriptions_controller_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 module RssTogether
   RSpec.describe Groups::SubscriptionsController, type: :controller do
+    before { ActiveJob::Base.queue_adapter = :test }
+
     routes { Engine.routes }
 
     let(:membership) { create(:membership) }
@@ -21,7 +23,7 @@ module RssTogether
     describe "DELETE #destroy" do
       before { delete :destroy, params: { group_id: group.id, id: subscription.id } }
 
-      it { expect(assigns(:subscription)).to be_destroyed }
+      it { expect(RemoveSubscriptionJob).to have_been_enqueued }
       it { expect(response).to redirect_to(group_subscriptions_path(group)) }
     end
   end

--- a/spec/jobs/rss_together/remove_subscription_job_spec.rb
+++ b/spec/jobs/rss_together/remove_subscription_job_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+module RssTogether
+  RSpec.describe RemoveSubscriptionJob, type: :job do
+    before { ActiveJob::Base.queue_adapter = :test }
+    after { clear_enqueued_jobs }
+
+    let(:subscription) { create(:subscription) }
+    let(:membership) { create(:membership, group: subscription.group) }
+    let(:item_1) { create(:item, feed: subscription.feed) }
+    let(:item_2) { create(:item, feed: subscription.feed) }
+
+    let(:perform) do
+      perform_enqueued_jobs { described_class.perform_later(subscription) }
+    end
+
+    describe "#perform" do
+      before do
+        create(:mark, reader: membership, item: item_1, unread: true)
+        create(:mark, reader: membership, item: item_2, unread: true)
+      end
+
+      it { expect { perform }.to change { Mark.count }.by(-2) }
+      it { expect { perform }.to change { membership.reload.unread_count }.from(2).to(0) }
+      it { expect { perform }.to change { Subscription.count }.by(-1) }
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures a lock is used when `Membership#unread_count` is being updated, such as when user marks all items as read.

It also introduces a background job, `RemoveSubscriptionJob`, which does the following:

- Removes all `Mark` records that a) belong to memberships on the group, and b) are of items from the removed feed
- Removes the `Subscription` record itself
- Updates the `unread_count` of the affected memberships (fixes the problem as described in the title)

As an aside, due to the use of the `counter_culture` gem, there is no need to calculate `unread_count` manually when new mark records are created.